### PR TITLE
Add buildType element to Jacoco script

### DIFF
--- a/.github/workflows/push_pr_to_master.yml
+++ b/.github/workflows/push_pr_to_master.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Test with Gradle
         run: ./gradlew test
 
-      - name: Create coverageReport
-        run: ./gradlew coverageReport
+      - name: Create coverageReport on release build
+        run: ./gradlew coverageReportRelease
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -32,7 +32,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
           directory: /home/runner/work/REMINDER_ANDROID/REMINDER_ANDROID/
-          files: ./app/build/reports/jacoco/coverageReport/coverageReport.xml
+          files: ./app/build/reports/jacoco/coverageReportRelease/coverageReportRelease.xml
 
       - name: action-slack
         uses: 8398a7/action-slack@v3.12.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.configurationcache.extensions.capitalized
+
 /*
  * Copyright (C) 2022 The N's lab Open Source Project
  *
@@ -22,6 +24,10 @@ plugins {
     id("dagger.hilt.android.plugin")
     id("kotlin-parcelize")
     jacoco
+}
+
+jacoco {
+    toolVersion = DependenciesVersions.JACOCO
 }
 
 android {
@@ -50,13 +56,68 @@ android {
             isDebuggable = false
             isMinifyEnabled = true
             signingConfig = signingConfigs.getByName("debug") // TODO make release key..
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    buildTypes.forEach { buildType ->
+        if (buildType.isMinifyEnabled) {
+            buildType.proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+            buildType.proguardFile("proguard-rules.pro")
+        }
+
+        // TODO with Flavor.
+        val buildName = buildType.name
+        val buildNameCapitalized = buildName.capitalized()
+        val taskName = "coverageReport${buildNameCapitalized}"
+        val dependOnName = "test${buildNameCapitalized}UnitTest"
+        tasks.register<JacocoReport>(taskName) {
+            dependsOn(dependOnName)
+
+            group = "reporting"
+            description = "Generate Jacoco coverage reports"
+
+            reports {
+                html.required.set(true)
+                // codecov depends on xml format report
+                if (buildType.name == "release") {
+                    xml.required.set(true)
+                }
+            }
+
+            val classFilters = setOf(
+                "**/R.class",
+                "**/R$*.class",
+                "**/BuildConfig.*",
+                "**/Manifest*.*",
+                "**/android/**",
+                "**/kotlin/**",
+                "com/android/**/*.class",
+                "**/model/**",
+                "**/view/**",
+                "**/di/**"
+            )
+
+            classDirectories.setFrom(files(
+                fileTree("${buildDir}/intermediates/javac/${buildName}/compile${buildNameCapitalized}JavaWithJavac/classes") {
+                    setExcludes(classFilters)
+                },
+                fileTree("${buildDir}/tmp/kotlin-classes/${buildName}") { setExcludes(classFilters) }
+            ))
+            sourceDirectories.setFrom(file("${projectDir}/src/main/java"))
+            executionData.setFrom(files("${buildDir}/jacoco/${dependOnName}.exec"))
+        }
+    }
+
+    sourceSets {
+        getByName("release") {
+            java.srcDirs("src/release/java")
+            res.srcDirs("src/release/res")
         }
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     packagingOptions {
@@ -64,51 +125,13 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+        jvmTarget = JavaVersion.VERSION_11.toString()
+        freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
     }
 
     buildFeatures {
         viewBinding = true
     }
-}
-
-jacoco {
-    toolVersion = DependenciesVersions.JACOCO
-}
-
-tasks.register<JacocoReport>("coverageReport") {
-    dependsOn("testDebugUnitTest")
-
-    group = "reporting"
-    description = "Generate Jacoco coverage reports"
-
-    reports {
-        html.required.set(true)
-        xml.required.set(true) // codecov depends on xml format report
-    }
-
-    val classFilters = setOf(
-        "**/R.class",
-        "**/R$*.class",
-        "**/BuildConfig.*",
-        "**/Manifest*.*",
-        "**/android/**",
-        "**/kotlin/**",
-        "com/android/**/*.class",
-        "**/model/**",
-        "**/view/**",
-        "**/di/**"
-    )
-
-    classDirectories.setFrom(files(
-        fileTree("${buildDir}/intermediates/javac/debug/compileDebugJavaWithJavac/classes") {
-            setExcludes(classFilters)
-        },
-        fileTree("${buildDir}/tmp/kotlin-classes/debug") { setExcludes(classFilters) }
-    ))
-    sourceDirectories.setFrom(file("${projectDir}/src/main/java"))
-    executionData.setFrom(files("${buildDir}/jacoco/testDebugUnitTest.exec"))
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,8 +116,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     packagingOptions {
@@ -125,7 +125,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
     }
 


### PR DESCRIPTION
- Separate tasks for debug and release.
- In codecov, the data created in the release build is processed to go up.
- We don't have to worry about compileError just yet. Because, `gladew test` can check compile error.