### PR TITLE
Remove Test with Gradle Tasks

### DIFF
--- a/.github/workflows/push_pr_to_master.yml
+++ b/.github/workflows/push_pr_to_master.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Test with Gradle
-        run: ./gradlew test
-
       - name: Create coverageReport on release build
         run: ./gradlew coverageReportRelease
 


### PR DESCRIPTION
In`coverageReportRelease`, CI already run testReleaseUnitTest .
So, removed `Test with Gradle Tasks`