### PR TITLE
Make `generateHandleScopeFunction` function

### DIFF
--- a/app/src/main/java/com/nlab/reminder/core/state/util/HandleScopeFunctions.kt
+++ b/app/src/main/java/com/nlab/reminder/core/state/util/HandleScopeFunctions.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 The N's lab Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nlab.reminder.core.state.util
+
+import com.nlab.reminder.core.state.Event
+import com.nlab.reminder.core.state.State
+import com.nlab.reminder.core.state.StateMachineHandleBuilder
+import com.nlab.reminder.core.state.StateMachineHandleScope
+
+/**
+ * @author thalys
+ */
+fun <E : Event, T> generateHandleScopeFunction(
+    block: suspend (StateMachineHandleScope<E>).() -> T
+): suspend (StateMachineHandleScope<E>).() -> T = { block() }
+
+@Suppress("unused")
+fun <E : Event, S : State, T> StateMachineHandleBuilder<E, S>.generateHandleScopeFunction(
+    block: suspend (StateMachineHandleScope<E>).() -> T
+): suspend (StateMachineHandleScope<E>).() -> T = generateHandleScopeFunction<E, T>(block)

--- a/app/src/main/java/com/nlab/reminder/domain/feature/home/HomeStateMachine.kt
+++ b/app/src/main/java/com/nlab/reminder/domain/feature/home/HomeStateMachine.kt
@@ -19,7 +19,7 @@ package com.nlab.reminder.domain.feature.home
 import com.nlab.reminder.core.effect.SideEffectHandle
 import com.nlab.reminder.core.kotlin.util.*
 import com.nlab.reminder.core.state.StateMachine
-import com.nlab.reminder.core.state.StateMachineHandleScope
+import com.nlab.reminder.core.state.util.generateHandleScopeFunction
 import com.nlab.reminder.domain.common.tag.TagRepository
 import kotlinx.coroutines.flow.*
 
@@ -51,7 +51,7 @@ fun HomeStateMachine(
     }
 
     handle {
-        suspend fun StateMachineHandleScope<in HomeEvent>.collectSnapshot() {
+        val collectSnapshot = generateHandleScopeFunction {
             val collectResult = catching {
                 getHomeSnapshot()
                     .map(HomeEvent::OnSnapshotLoaded)

--- a/app/src/test/java/com/nlab/reminder/core/state/util/HandleScopeFunctionsKtTest.kt
+++ b/app/src/test/java/com/nlab/reminder/core/state/util/HandleScopeFunctionsKtTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 The N's lab Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nlab.reminder.core.state.util
+
+import com.nlab.reminder.core.state.EventProcessor
+import com.nlab.reminder.core.state.StateMachineHandleScope
+import com.nlab.reminder.core.state.TestEvent
+import com.nlab.reminder.test.once
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+/**
+ * @author thalys
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HandleScopeFunctionsKtTest {
+    @Test
+    fun generateHandleScopeFunction() = runTest {
+        val eventProcessor: EventProcessor<TestEvent> = mock()
+        val scope = StateMachineHandleScope(
+            mock(),
+            eventProcessor
+        )
+        val operator: (StateMachineHandleScope<TestEvent>) -> Unit = mock()
+        val f = generateHandleScopeFunction {
+            operator(this)
+        }
+        f(scope)
+
+        verify(operator, once())(scope)
+    }
+}


### PR DESCRIPTION
Usage in handle DSL
```kotlin
handle {
      val f = generateHandleScopeFunction { 
            // some job
      }
      anyEvent {
           anyState { f() }
      }
}
```