### PR TITLE
Fix DefaultCompleteMarkRepositoryTest.`insert executed on io thread` option

### DIFF
--- a/app/src/test/java/com/nlab/reminder/domain/common/schedule/impl/DefaultCompleteMarkRepositoryTest.kt
+++ b/app/src/test/java/com/nlab/reminder/domain/common/schedule/impl/DefaultCompleteMarkRepositoryTest.kt
@@ -33,7 +33,7 @@ class DefaultCompleteMarkRepositoryTest {
     @Test
     fun `insert executed on io thread`() = runTest {
         val repository = DefaultCompleteMarkRepository()
-        val count = genInt()
+        val count = genInt(min = 5, max = 10)
         (0 until count)
             .map { ScheduleId(it.toLong()) }
             .map { scheduleId ->


### PR DESCRIPTION
Make range of random count to [5..10]