### PR TITLE
Fix #254 - When View is deleted, ComposeView is also released

### DIFF
--- a/app/src/main/java/com/nlab/reminder/core/android/fragment/ComponentFragment.kt
+++ b/app/src/main/java/com/nlab/reminder/core/android/fragment/ComponentFragment.kt
@@ -28,8 +28,7 @@ import androidx.fragment.app.Fragment
  * @author Doohyun
  */
 abstract class ComponentFragment : Fragment() {
-    private var _composeView: ComposeView? = null
-    val composeView: ComposeView get() = checkNotNull(_composeView)
+    private var composeView: ComposeView? = null
 
     final override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,11 +36,18 @@ abstract class ComponentFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext())
         .apply { setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed) }
-        .also { _composeView = it }
+        .also { composeView = it }
 
     final override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         onViewCreated(savedInstanceState)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        composeView = null
+    }
+
     protected abstract fun onViewCreated(savedInstanceState: Bundle?)
+
+    internal fun requireComposeView(): ComposeView = checkNotNull(composeView)
 }

--- a/app/src/main/java/com/nlab/reminder/core/android/fragment/ComponentFragments.kt
+++ b/app/src/main/java/com/nlab/reminder/core/android/fragment/ComponentFragments.kt
@@ -22,5 +22,5 @@ import androidx.compose.runtime.Composable
  * @author Doohyun
  */
 fun ComponentFragment.setContent(content: @Composable () -> Unit) {
-    composeView.setContent(content)
+    requireComposeView().setContent(content)
 }


### PR DESCRIPTION
about #254 

#### Issue:
When using Navigation for navigation, the View of the Fragment gets removed, but the ComposeView remains, leading to a memory leak.

#### Fix: 
Release the ComposeView at the onDestroyView lifecycle callback.