### PR TITLE
Extends InsertDummyInfoToDatabaseMacro 

### DIFF
--- a/app/src/androidTest/kotlin/com/nlab/reminder/macro/InsertDummyDataToDatabaseMacro.kt
+++ b/app/src/androidTest/kotlin/com/nlab/reminder/macro/InsertDummyDataToDatabaseMacro.kt
@@ -42,7 +42,7 @@ import kotlin.time.Clock
  */
 @RunWith(AndroidJUnit4::class)
 class InsertDummyDataToDatabaseMacro {
-    private val faker: Faker = Faker(Locale.forLanguageTag(/* languageTag = */ "ko"))
+    private val faker: Faker = Faker(Locale.forLanguageTag("ko"))
     private val tagTextInputs: List<String> = listOf(
         "집안일",
         "약속",


### PR DESCRIPTION
- Rename file to `InsertDummyDataToDatabaseMacro.kt` for clarity.
- Introduce `replaceDummyData` to centralize data insertion logic.
- Add test cases for inserting shuffled, small amounts, and small amounts of shuffled dummy data.