### PR TITLE
Enable KSP project isolation

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
-        includeBuild("build-logic")
         gradlePluginPortal()
         google()
         mavenCentral()


### PR DESCRIPTION
## Description
This PR enables **KSP project isolation** to improve build performance and ensure compatibility with modern Gradle best practices.
### Key Changes
- **Enable KSP Isolation**: Added `ksp.project.isolation.enabled=true` to `gradle.properties`. This allows the KSP processor to handle projects in isolation, leading to faster parallel builds.
- **Refactor `settings.gradle.kts`**: Moved `includeBuild("build-logic")` outside the `repositories` block. This aligns with the structure used in the **Now In Android (NIA)** project and improves the readability of the plugin management configuration.
### Reference
- Based on NIA project configurations (Ref: [android/nowinandroid#1392](https://github.com/android/nowinandroid/pull/1392))