### PR TITLE
Add agent guidelines structure and commit rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Reminder Android Project (AI Agent Guide)
+
+This file serves as a guide for AI coding assistants (agents) to understand the architecture, module layout, and build/test workflows of the **REMINDER_ANDROID** project.
+
+---
+
+## 🏗️ Architecture & Tech Stack
+
+This project is a modular, reactive Android application that focuses on clean architecture, loose coupling, and testability.
+
+*   **State Management / Architecture:** Strictly follows the **MVI (Model-View-Intent)** architecture pattern.
+    *   State flows are managed using **StateKit** (`:statekit` modules), which is a custom lightweight MVI/state management framework leveraging Kotlin Coroutines and Flows.
+*   **Dependency Injection (DI):** Managed via **Hilt**. Convention plugins (e.g., `nlab.android.hilt`, `nlab.android.library.di`) are defined under `build-logic` to enforce consistent DI setups.
+*   **UI:** Built primarily with **Jetpack Compose** (via `nlab.android.library.compose` convention) alongside traditional view architecture components where necessary.
+*   **Asynchronous Processing:** Powered by **Kotlin Coroutines** and **Flows**.
+*   **Testing Strategy:** Heavily practices **TDD (Test-Driven Development)**, aiming for near 100% test coverage. Jacoco plugins (`nlab.android.library.jacoco`, `nlab.android.application.jacoco`) are integrated for code coverage reporting.
+
+---
+
+## 📦 Module Structure
+
+The project is highly modularized to ensure separation of concerns and faster build times:
+
+```
+REMINDER_ANDROID/
+├── app/                      # Main application entry point & Hilt setup
+├── feature/                  # Feature-level modules
+│   ├── home/                 # Main home screen feature
+│   └── all/                  # Aggregate or common feature entry points
+├── core/                     # Shared foundation and utility modules
+│   ├── component/            # Reusable UI components (e.g., schedulelist, tag, toolbar, usermessage)
+│   ├── data/                 # Data layer definitions
+│   ├── data-impl/            # Repository and data access implementations
+│   ├── local/                # Local database / Room persistence
+│   ├── network/              # Remote network API access (Retrofit, etc.)
+│   ├── designsystem/         # Design system tokens, themes, and basic UI elements
+│   ├── android/              # Platform wrappers and context utilities
+│   └── androidx/             # Compose, Fragment, Recyclerview, and Navigation wrappers
+├── statekit/                 # Custom state management framework (core, dsl, lifecycle, foundation)
+└── testkit/                  # Shared test utilities and helper modules
+```
+
+*   **Helper Test Modules:** Core component modules have matching `-test` modules (e.g., `:core:component:tag-test`, `:core:component:schedulelist-test`) containing mock data, test configurations, and utilities to isolate test scopes.
+
+---
+
+## 🛠️ Build & Test Commands
+
+Use the following Gradle commands to compile, check code formatting, and run tests.
+
+### Build and Compile
+*   **Assemble Debug APK:**
+    ```bash
+    ./gradlew :app:assembleDebug
+    ```
+*   **Clean Build:**
+    ```bash
+    ./gradlew clean build
+    ```
+
+### Running Tests (TDD)
+This project requires high code coverage. Always verify your changes with tests before submitting code reviews.
+
+*   **Run All Unit Tests:**
+    ```bash
+    ./gradlew test
+    ```
+*   **Run Tests for a Specific Module:**
+    ```bash
+    ./gradlew :core:component:schedulelist:test
+    ```
+*   **Run Instrumented/Android Tests:**
+    ```bash
+    ./gradlew connectedAndroidTest
+    ```
+
+### Code Coverage (Jacoco)
+*   **Generate Jacoco Test Reports:**
+    ```bash
+    ./gradlew jacocoTestReport
+    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Reminder Android Project (AI Agent Guide)
 
+## 📋 Guidelines Index
+
+Detailed guidelines are in `docs/guidelines/`. Read the relevant file before performing the task.
+
+| File | When to read |
+|------|--------------|
+| [`docs/guidelines/commit-rules.md`](docs/guidelines/commit-rules.md) | Before creating any git commit |
+
+---
+
+
 This file serves as a guide for AI coding assistants (agents) to understand the architecture, module layout, and build/test workflows of the **REMINDER_ANDROID** project.
 
 ---

--- a/docs/guidelines/commit-rules.md
+++ b/docs/guidelines/commit-rules.md
@@ -1,0 +1,80 @@
+# Commit Rules
+
+## Format
+
+```
+<Type> #<issue-number> - <subject>
+```
+
+- **Type**: `Implement` / `Fix` / `Refactor` / `Chore`
+- **Issue number**: GitHub issue number, or `N/A` if not applicable
+- **Subject**: Written in English
+
+---
+
+## Types
+
+| Type | When to use |
+|------|-------------|
+| `Implement` | New feature or functionality |
+| `Fix` | Bug fix |
+| `Refactor` | Code restructuring without behavior change |
+| `Chore` | Build config, dependencies, and other miscellaneous tasks |
+
+---
+
+## Body (Implement only)
+
+`Implement` commits require a detailed body describing **what** was changed and **why** it was implemented that way.
+
+```
+Implement #<issue-number> - <subject>
+
+- <reason or detail>
+- <reason or detail>
+- <reason or detail>
+```
+
+---
+
+## AI Collaboration (Co-authored-by)
+
+When working with an AI coding assistant (like Antigravity) and you want to attribute the work to both yourself and the AI, include the `Co-authored-by` trailer at the bottom of the commit message (separated by an empty line).
+
+```
+Implement #789 - Add agent guidelines structure and commit rules
+
+- Created docs/guidelines/ directory to house project-wide guidelines
+- Added commit-rules.md defining the commit message format
+
+Co-authored-by: AI-Assistant <assistant@example.com>
+```
+
+---
+
+## Examples
+
+
+### Implement
+```
+Implement #312 - Add tag filtering to ScheduleListScreen
+
+- Introduced TagFilterBar composable above the schedule list to allow users to filter by tag
+- Filter state is hoisted to ScheduleListViewModel and exposed via UiState to follow MVI conventions
+- Filtering is applied in the use case layer to keep the ViewModel free of business logic
+```
+
+### Fix
+```
+Fix #401 - Resolve StateFlow not emitting on configuration change
+```
+
+### Refactor
+```
+Refactor #278 - Extract alarm scheduling logic into AlarmScheduler use case
+```
+
+### Chore
+```
+Chore N/A - Upgrade Kotlin to 2.0.0 and update related dependencies
+```


### PR DESCRIPTION
## Overview
- Established a project guidelines folder structure that can be shared by both humans and AI agents.
- Added the first guideline document defining the project's commit message rules.

## Key Changes
- **Guidelines Directory**: Created the `docs/guidelines/` directory to serve as a central location for future project rules and conventions.
- **Commit Rules Document**: Added `docs/guidelines/commit-rules.md` to define the commit message convention (`Type #issue - subject`) with specified types (`Implement`, `Fix`, `Refactor`, `Chore`) and body requirements for `Implement`.
- **AGENTS.md Update**: Added a `Guidelines Index` table at the top of `AGENTS.md` to ensure AI agents read the detailed rules before performing tasks.