### PR TITLE
Add branch naming and merging rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ Detailed guidelines are in `docs/guidelines/`. Read the relevant file before per
 
 | File | When to read |
 |------|--------------|
-| [`docs/guidelines/commit-rules.md`](docs/guidelines/commit-rules.md) | Before creating any git commit |
 | [`.agents/skills/`](.agents/skills/) | For any project custom automation tasks (e.g. creating git worktrees, etc.) |
+| [`docs/guidelines/branch-rules.md`](docs/guidelines/branch-rules.md) | Before creating or merging any git branch |
+| [`docs/guidelines/commit-rules.md`](docs/guidelines/commit-rules.md) | Before creating any git commit |
 
 ---
 

--- a/docs/guidelines/branch-rules.md
+++ b/docs/guidelines/branch-rules.md
@@ -1,0 +1,69 @@
+# Branch Rules
+
+This document defines the branching strategy and naming conventions for the REMINDER_ANDROID project. Agents and developers must read this document before starting any tasks to select the correct target branch.
+
+---
+
+## 1. Allowed Branch Types
+
+Only the following three types of branches are used in this project:
+
+* **`master`**
+  * The main production-ready branch. It must always be buildable and stable.
+* **`epic/issue<issue-number>`**
+  * Inspired by Jira's Epic. Used for large-scale tasks or major features that contain multiple sub-tasks.
+  * Example: `epic/issue795`
+* **`feature/issue<issue-number>`**
+  * Represents a single task.
+  * **Important**: Regardless of the task nature (e.g., Fix, Refactor, Chore), all single task branches must use the `feature/` prefix.
+  * Example: `feature/issue796`
+
+---
+
+## 2. Branch Merging Strategy & Workflow
+
+The branching and merging flow depends on the scale of the task.
+
+### Scenario A: Large-scale Work (Epic-based Development)
+For larger work composed of multiple sub-tasks:
+
+1. **Create Epic Branch**: Create an `epic/issue<issue-number>` branch from `master`.
+2. **Create Feature Branch**: Create a `feature/issue<issue-number>` branch from the `epic/issue<issue-number>` branch.
+3. **Merge to Epic**: Once the feature is complete, **create a Pull Request targeting the `epic/issue<issue-number>` branch** (not `master`) and merge it.
+4. **Final Merge to Master**: Once all sub-feature branches are merged and the epic is complete, merge the `epic/issue<issue-number>` branch into `master`.
+
+```mermaid
+gitGraph
+    commit id: "Initial"
+    branch epic/issue100
+    checkout epic/issue100
+    commit id: "Epic Start"
+    branch feature/issue101
+    checkout feature/issue101
+    commit id: "Task 1"
+    checkout epic/issue100
+    merge feature/issue101
+    branch feature/issue102
+    checkout feature/issue102
+    commit id: "Task 2"
+    checkout epic/issue100
+    merge feature/issue102
+    checkout master
+    merge epic/issue100 id: "Merge Epic to Master"
+```
+
+### Scenario B: Small-scale Work (Standalone Task Development)
+For simple bug fixes, refactoring, or small standalone features:
+
+1. **Create Feature Branch**: Create a `feature/issue<issue-number>` branch from `master`.
+2. **Merge to Master**: Once complete, **create a Pull Request targeting `master`** and merge it directly.
+
+```mermaid
+gitGraph
+    commit id: "Initial"
+    branch feature/issue201
+    checkout feature/issue201
+    commit id: "Fix / Implement"
+    checkout master
+    merge feature/issue201 id: "Merge Task to Master"
+```

--- a/docs/guidelines/commit-rules.md
+++ b/docs/guidelines/commit-rules.md
@@ -6,7 +6,7 @@
 <Type> #<issue-number> - <subject>
 ```
 
-- **Type**: `Implement` / `Fix` / `Refactor` / `Chore`
+- **Type**: `Implement` / `Fix` / `Refactor` / `Chore` / `Docs`
 - **Issue number**: GitHub issue number, or `N/A` if not applicable
 - **Subject**: Written in English
 
@@ -20,6 +20,7 @@
 | `Fix` | Bug fix |
 | `Refactor` | Code restructuring without behavior change |
 | `Chore` | Build config, dependencies, and other miscellaneous tasks |
+| `Docs` | Documentation updates (e.g., guidelines, WIKI, README) |
 
 ---
 


### PR DESCRIPTION
## Description
This PR introduces the branching and merging guidelines for the project and updates the agent setup documentation. It also officially introduces the `Docs` commit type in the project's commit rules.

## Changes
- **New Guideline**: Created `docs/guidelines/branch-rules.md` to document the branching strategy (`master`, `epic/issue<number>`, and `feature/issue<number>`) and its corresponding merge workflows.
- **Agent Guide Update**: Updated the Guidelines Index in `AGENTS.md` to include `branch-rules.md` and sorted the table in alphabetical order.
- **Commit Rules Expansion**: Added `Docs` as an official commit type in `docs/guidelines/commit-rules.md` for handling documentation updates (guidelines, README, WIKI, etc.).

## Related Issue
Closes #796